### PR TITLE
Unable to update state of already matched card

### DIFF
--- a/src/hooks/useGameSetup/useGameSetup.ts
+++ b/src/hooks/useGameSetup/useGameSetup.ts
@@ -56,7 +56,10 @@ const useGameSetup = () => {
       event: React.MouseEvent<HTMLDivElement, MouseEvent>,
       card: MCGameCard
     ): void => {
-      if (state.cardsShown.counter < MAX_CARDS_SHOWN_PER_TURN) {
+      if (
+        state.cardsShown.counter < MAX_CARDS_SHOWN_PER_TURN &&
+        !card.isMatched
+      ) {
         dispatch({
           type: MCGameActionType.SHOW_CARD,
           payload: card,


### PR DESCRIPTION
- Fix updating matched card state issue when card is clicked.
- Now the `onClick` handler will ask if any card is matched or not to update its status 