### PR TITLE
Fix game status processing at game init

### DIFF
--- a/src/store/app.reducer.ts
+++ b/src/store/app.reducer.ts
@@ -7,6 +7,7 @@ export const initialState: MCAppState = {
 };
 
 function determineCardListMatches(cardDeck: MCGameCardDeck): boolean {
+  if (cardDeck.length === 0) return false;
   return cardDeck.every((card) => card.isMatched);
 }
 


### PR DESCRIPTION
- When game inits game status should return `inProgress` instead of `idle` until game is over due to coundown timer
- Check if `cardDeck` is empty to return `false` instead of `true` via `Array.prototype.every` method to address this issue