### PR TITLE
Reload game and session storage flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "eject": "craco eject"
+    "eject": "craco eject",
+    "reinstall": "rm -rf node_modules && yarn install"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/card/card.component.tsx
+++ b/src/components/card/card.component.tsx
@@ -26,10 +26,10 @@ const Card: React.FC<CardProps> = ({ card, onTap }) => {
         src={require(`@assets/cover_card.png`)}
       />
       <img
-        className={`p-1 ${
+        className={`w-full h-full rounded-sm ${
           isHidden ? "invisible" : "visible"
-        } absolute select-none pointer-events-none`}
-        src={require(`@assets/${id}.png`)}
+        }`}
+        src={card.src}
       />
     </div>
   );

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -4,7 +4,7 @@ export interface MCSingleComponentProps {
 
 export type MCGameMaxCardsInDeck = 10;
 
-export type MCGameMaxAvailableCards = 16;
+export type MCGameMaxAvailableCards = 16 | number;
 
 export type MCGameLevelKeys = "easy" | "medium" | "hard";
 
@@ -19,6 +19,7 @@ export interface MCGameLevel {
 export type MCGameCard = {
   id: string;
   uid: string;
+  src: string;
   isHidden: boolean;
   isMatched: boolean;
 };
@@ -42,6 +43,7 @@ export interface MCAppState {
 }
 
 export interface MCGameState {
+  error: string | null;
   cardDeck: MCGameCardDeck;
   cardsShown: MCGameCardsShown;
 }

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -8,8 +8,8 @@ export function callAll(...fns: Array<Function | undefined>) {
   };
 }
 
-export function getRandomCharCode(): number {
-  const MAX_AVAILABLE_CARDS: MCGameMaxAvailableCards = 16;
+export function getRandomCharCode(maxCards: MCGameMaxAvailableCards = 16): number {
+  const MAX_AVAILABLE_CARDS: MCGameMaxAvailableCards = maxCards;
   const INITIAL_CHAR_CODE = 97;
   return INITIAL_CHAR_CODE + Math.floor(Math.random() * MAX_AVAILABLE_CARDS);
 };

--- a/src/contexts/game-context/game.provider.tsx
+++ b/src/contexts/game-context/game.provider.tsx
@@ -1,17 +1,12 @@
 import React, { useReducer } from "react";
 
 import { GameContext } from "@contexts";
-import { MCGameCardDeck, MCSingleComponentProps } from "@config";
+import { MCSingleComponentProps } from "@config";
 import { gameReducer, gameInitialState } from "@store";
-import { useSessionStorage } from "@hooks";
 
 const GameProvider: React.FC<MCSingleComponentProps> = ({ children }) => {
-  const [cardDeckStorage] = useSessionStorage("cardDeck", gameInitialState.cardDeck) as [
-    MCGameCardDeck
-  ];
   const [state, dispatch] = useReducer(gameReducer, {
     ...gameInitialState,
-    cardDeck: cardDeckStorage,
   });
 
   const contextValue = React.useMemo(
@@ -20,9 +15,7 @@ const GameProvider: React.FC<MCSingleComponentProps> = ({ children }) => {
   );
 
   return (
-    <GameContext.Provider value={contextValue}>
-      {children}
-    </GameContext.Provider>
+    <GameContext.Provider value={contextValue}>{children}</GameContext.Provider>
   );
 };
 

--- a/src/hooks/useMainMenuSetup/useMainMenuSetup.ts
+++ b/src/hooks/useMainMenuSetup/useMainMenuSetup.ts
@@ -28,7 +28,6 @@ const useMainMenuSetup = () => {
     React.useState<MCGameLevelKeys>("easy");
 
   const cardDeck = React.useMemo(
-    // () => shuffleDeck(getInitialRandomList(16 as MCGameMaxAvailableCards)),
     () =>
       shuffleDeck(
         appState.imageAssets.filter(

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 
 const useSessionStorage = (key: string, initialValue: unknown = null) => {
   const [value, setValue] = useState<unknown>(() => {
-    const storedValue = sessionStorage.getItem(key);
+    const storedValue = window.sessionStorage.getItem(key);
     if (storedValue) return JSON.parse(storedValue);
     if (
       initialValue !== null &&

--- a/src/store/game.actions.ts
+++ b/src/store/game.actions.ts
@@ -1,4 +1,4 @@
-import { MCGameCard, MCGameCardDeck } from "@config";
+import { MCAppPreRenderedImgAsset, MCGameCard, MCGameCardDeck } from "@config";
 
 export enum MCGameActionType {
   START_DECK = "Start Deck",
@@ -6,6 +6,7 @@ export enum MCGameActionType {
   SHOW_CARD = "Show Card",
   RESET_DECK = "Reset Deck",
   CLEAR_GAME = "Clear Game",
+  ERROR = "Error",
 }
 
 export type MCGameAction = {
@@ -13,4 +14,4 @@ export type MCGameAction = {
   payload?: MCGameActionPayload;
 };
 
-export type MCGameActionPayload = MCGameCard | MCGameCardDeck;
+export type MCGameActionPayload = MCGameCard | MCGameCardDeck | MCAppPreRenderedImgAsset[];


### PR DESCRIPTION
- Remove shuffled UI card relative paths persisted by session storage and replace it by saving all image assets relative paths into a single field to then be loaded by either main menu or game UI images components
- Image assets are loaded and held by webpack load context API
- Handle new error state when loading a new game if image assets aren't persisted from sessionStorage API
