### PR TITLE
Bug: Refresh app cards while reloading app issue

### DIFF
--- a/src/components/card/card.component.tsx
+++ b/src/components/card/card.component.tsx
@@ -20,13 +20,13 @@ const Card: React.FC<CardProps> = ({ card, onTap }) => {
       onClick={(ev) => onTap(ev, card)}
     >
       <img
-        className={`p-1 ${
+        className={`p-1 absolute select-none pointer-events-none ${
           isHidden ? "visible" : "invisible"
-        } absolute select-none pointer-events-none`}
+        }`}
         src={require(`@assets/cover_card.png`)}
       />
       <img
-        className={`w-full h-full rounded-sm ${
+        className={`p-1 absolute select-none pointer-events-none ${
           isHidden ? "invisible" : "visible"
         }`}
         src={card.src}

--- a/src/components/card/card.component.tsx
+++ b/src/components/card/card.component.tsx
@@ -11,7 +11,7 @@ interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ card, onTap }) => {
-  const { id, isHidden } = card;
+  const { isHidden } = card;
   return (
     <div
       className={`w-16 sm:w-28 md:w-36 lg:w-48 h-16 sm:h-28 md:h-36 lg:h-48 ${

--- a/src/contexts/app-context/app.provider.tsx
+++ b/src/contexts/app-context/app.provider.tsx
@@ -6,12 +6,16 @@ import { appReducer, initialState } from "@store";
 import { MCAppState, MCSingleComponentProps } from "@config";
 
 const AppProvider: React.FC<MCSingleComponentProps> = ({ children }) => {
-  const [appStateStorage] = useSessionStorage("appState", initialState) as [
-    MCAppState
-  ];
+  const { gameLevel, gameProgress, gameStatus, imageAssets } = initialState;
+  const [appStateStorage] = useSessionStorage("appState", {
+    gameLevel,
+    gameProgress,
+    gameStatus,
+  }) as [Pick<MCAppState, "gameLevel" | "gameProgress" | "gameStatus">];
 
   const [state, dispatch] = useReducer(appReducer, {
     ...appStateStorage,
+    imageAssets,
   });
 
   const contextValue = React.useMemo(
@@ -20,9 +24,7 @@ const AppProvider: React.FC<MCSingleComponentProps> = ({ children }) => {
   );
 
   return (
-    <AppContext.Provider value={contextValue}>
-      {children}
-    </AppContext.Provider>
+    <AppContext.Provider value={contextValue}>{children}</AppContext.Provider>
   );
 };
 

--- a/src/hooks/useGameSetup/useGameSetup.ts
+++ b/src/hooks/useGameSetup/useGameSetup.ts
@@ -21,7 +21,7 @@ const useGameSetup = () => {
     type: "end",
     isShown: false,
   });
-  const { gameStatus, gameLevel, gameProgress } = appState;
+  const { gameStatus, gameLevel, gameProgress, imageAssets } = appState;
   const { cardDeck } = gameState;
   const [countdown, setCountdown] = React.useState<number>(gameLevel.countdown);
   const MAX_CARDS_SHOWN_PER_TURN = 2;
@@ -48,7 +48,7 @@ const useGameSetup = () => {
   const handleResetGameClick = () => {
     appDispatch({ type: MCActionType.CHANGE_STATUS, payload: "new" });
     gameProgress === "win"
-      ? gameDispatch({ type: MCGameActionType.START_DECK })
+      ? gameDispatch({ type: MCGameActionType.START_DECK, payload: imageAssets })
       : gameDispatch({ type: MCGameActionType.RESET_DECK });
     appDispatch({
       type: MCActionType.CHANGE_PROGRESS_BY_VALUE,

--- a/src/hooks/useMainMenuSetup/useMainMenuSetup.ts
+++ b/src/hooks/useMainMenuSetup/useMainMenuSetup.ts
@@ -26,15 +26,16 @@ const useMainMenuSetup = () => {
   };
   const [selectedGameLevel, setSelectedGameLevel] =
     React.useState<MCGameLevelKeys>("easy");
+  const { imageAssets } = appState;
 
   const cardDeck = React.useMemo(
     () =>
-      shuffleDeck(
-        appState.imageAssets.filter(
-          (asset) => !asset.imgId.includes("cover_card")
-        )
-      ),
-    [appState.imageAssets]
+      imageAssets?.length > 0
+        ? shuffleDeck(
+            imageAssets.filter((asset) => !asset.imgId.includes("cover_card"))
+          )
+        : [],
+    [imageAssets]
   );
 
   const handleStartGameClick = () => {};
@@ -65,6 +66,7 @@ const useMainMenuSetup = () => {
     });
     gameDispatch({
       type: MCGameActionType.START_DECK,
+      payload: imageAssets,
     });
     navigate(MCGameRoutePath.PLAY);
   };

--- a/src/store/app.reducer.ts
+++ b/src/store/app.reducer.ts
@@ -84,7 +84,7 @@ export function appReducer(state: MCAppState, action: MCAppAction): MCAppState {
       };
     }
     case MCActionType.CLEAR_GAME: {
-      return { ...initialState, imageAssets: state.imageAssets };
+      return { ...initialState };
     }
     default:
       return state;

--- a/src/store/game.reducer.ts
+++ b/src/store/game.reducer.ts
@@ -112,9 +112,9 @@ export function gameReducer(
 ): MCGameState {
   switch (action.type) {
     case MCGameActionType.START_DECK: {
-      const sessionStorage = window.sessionStorage.getItem("appState");
-      if (sessionStorage) {
-        const { imageAssets } = JSON.parse(sessionStorage);
+      const { payload } = action;
+      const imageAssets = payload as MCAppPreRenderedImgAsset[];
+      if (imageAssets.length > 0) {
         return {
           ...gameInitialState,
           cardDeck: shuffleDeck<MCGameCardDeck>(
@@ -125,7 +125,7 @@ export function gameReducer(
       return {
         ...gameInitialState,
         cardDeck: [],
-        error: 'No image assets found in session storage',
+        error: 'No loaded image assets',
       };
     }
     case MCGameActionType.MATCHED_CARDS: {


### PR DESCRIPTION
- Current deployed app in Netlify cannot reload image assets when app gets refreshed while game is in progress. This PR gets rid of persisting image assets through sessionStorage API and it reloads all assets once the app gets refreshed and is in current game in-progress status